### PR TITLE
Add in-app guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 batch-*
+generatedGitBranch.json

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+node ./gitBranch.js

--- a/gitBranch.js
+++ b/gitBranch.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const execSyncWrapper = command => {
+  let stdout = null;
+  try {
+    stdout = execSync(command).toString().trim();
+  } catch (error) {
+    console.error(error);
+  }
+  return stdout;
+};
+
+const getGitBranch = () => {
+  let gitBranch = execSyncWrapper('git rev-parse --abbrev-ref HEAD');
+
+  const obj = {
+    gitBranch,
+  };
+
+  const filePath = path.resolve('todo-app/public', 'generatedGitBranch.json');
+  const fileContents = JSON.stringify(obj, null, 2);
+
+  fs.writeFileSync(filePath, fileContents);
+  console.log(`Wrote the current git branch to ${filePath}`);
+};
+
+getGitBranch();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,25 @@
       "workspaces": [
         "packages/my-own-react"
       ],
+      "dependencies": {
+        "husky": "^8.0.2"
+      },
       "devDependencies": {
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/js-tokens": {
@@ -71,6 +88,11 @@
     }
   },
   "dependencies": {
+    "husky": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "The workspace setup for the build your own react workshop!",
   "scripts": {
-    "start": "cd todo-app && npm start",
+    "start": "npm run git-branch && cd todo-app && npm start",
     "postinstall": "cd todo-app && npm ci",
-    "format": "prettier --write \"**/*.+(js|jsx|json|yml|yaml|css|md|vue)\""
+    "format": "prettier --write \"**/*.+(js|jsx|json|yml|yaml|css|md|vue)\"",
+    "git-branch": "node ./gitBranch.js",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -21,5 +23,8 @@
   ],
   "devDependencies": {
     "prettier": "^2.7.1"
+  },
+  "dependencies": {
+    "husky": "^8.0.2"
   }
 }

--- a/todo-app/public/index.html
+++ b/todo-app/public/index.html
@@ -27,8 +27,37 @@
     <title>React App</title>
   </head>
   <body>
+    <script src="./walkthroughText.js"></script>
+    <script>
+      function openSnackbar() {
+        var snackbar = document.getElementById('snackbar');
+        // get git branch and correct walkthrough text
+        fetch('generatedGitBranch.json')
+          .then(function (response) {
+            return response.json();
+          })
+          .then(function (data) {
+            console.log({ data });
+            var text = document.createTextNode(walkthroughText[data.gitBranch]);
+            snackbar.appendChild(text);
+          })
+          .catch(function (err) {
+            console.log(err);
+          });
+
+        snackbar.className = 'show';
+      }
+      function closeSnackbar() {
+        var snackbar = document.getElementById('snackbar');
+        snackbar.className = '';
+      }
+    </script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="snackbar">
+      <button id="closeBtn" onClick="closeSnackbar()">X</button>
+    </div>
+    <button id="snackbarBtn" onClick="openSnackbar()">Open Step Info</button>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/todo-app/public/index.html
+++ b/todo-app/public/index.html
@@ -37,9 +37,14 @@
             return response.json();
           })
           .then(function (data) {
-            console.log({ data });
-            var text = document.createTextNode(walkthroughText[data.gitBranch]);
-            snackbar.appendChild(text);
+            var p = document.getElementById('snackbarText');
+            var text =
+              walkthroughText[data.gitBranch] ||
+              'This branch has no relevant hints.';
+
+            var textNode = document.createTextNode(text);
+            p.appendChild(textNode);
+            snackbar.appendChild(p);
           })
           .catch(function (err) {
             console.log(err);
@@ -50,14 +55,23 @@
       function closeSnackbar() {
         var snackbar = document.getElementById('snackbar');
         snackbar.className = '';
+        // clear text
+        var p = document.getElementById('snackbarText');
+        p.innerHTML = '';
       }
+
+      // open snackbar onload
+      window.onload = function () {
+        openSnackbar();
+      };
     </script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="snackbar">
       <button id="closeBtn" onClick="closeSnackbar()">X</button>
+      <p id="snackbarText"></p>
     </div>
-    <button id="snackbarBtn" onClick="openSnackbar()">Open Step Info</button>
+    <button id="snackbarBtn" onClick="openSnackbar()">Open Hint</button>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/todo-app/public/walkthroughText.js
+++ b/todo-app/public/walkthroughText.js
@@ -1,15 +1,24 @@
 var walkthroughText = {
-  main: 'This app is currently using the real React. Checkout the branch chapter-1/step-1 to begin the journey to creating your own React.',
+  main: 'This app is currently using the real React. Checkout the branch chapter-1/step-1 to begin the journey to creating your own.',
   'chapter-1/step-1':
-    'Check out the render function in dom-handlers.js. This is where the rendering of elements to the DOM happens.',
-  'chapter-1/step-2': 'chapter-1/step-2',
-  'chapter-1/step-3': 'chapter-1/step-3',
-  'chapter-1/step-4': 'chapter-1/step-4',
-  'chapter-2/step-1': 'chapter-2/step-1',
-  'chapter-2/step-2': 'chapter-2/step-2',
-  'chapter-3/step-1': 'chapter-3/step-1',
-  'chapter-3/step-2': 'chapter-3/step-2',
-  'chapter-4/step-1': 'chapter-4/step-1',
-  'chapter-4/step-2': 'chapter-4/step-2',
-  final: '',
+    'Chapter 1, Step 1:\n\nYour React cannot render anything yet. Check out the render function in dom-handlers.js. This is where the rendering of elements to the DOM happens.',
+  'chapter-1/step-2':
+    'Chapter 1, Step 2:\n\nSo you can render an empty div. But html elements need attributes like "id". How can we add these?',
+  'chapter-1/step-3':
+    'Chapter 1, Step 3:\n\nAttributes added. Now let us focus on adding children and getting some content on the page!',
+  'chapter-1/step-4':
+    'Chapter 1, Step 4:\n\nYour React can handle children but React is all about rendering components. What is a component? What do we need to consider to render one?',
+  'chapter-2/step-1':
+    'Chapter 2, Step 1:\n\nYour React can render components! But for our app to be dynamic we need our components to be stateful. Checkout hooks.js and think about how we can complete the useState hook. The counter should work at the end of this step.',
+  'chapter-2/step-2':
+    'Chapter 2, Step 2:\n\nWe have state! But what if we want our components to have more than one state? We have a problem currently. Look what happens when you increase the counter...',
+  'chapter-3/step-1':
+    'Chapter 3, Step 1:\n\nState completed. Now we need to look at the VDOM and handle diffing. Check the docs for more detail on this topic.',
+  'chapter-3/step-2':
+    "Chapter 3, Step 2:\n\nWe are now sorting through props and diffing types correctly. But we need to still implement the logic for each type. Let's work on the case when a node needs to be added.",
+  'chapter-4/step-1':
+    'Chapter 4, Step 1:\n\nDiffing accomplished. Now onto hooks and useEffect so our app can handle side-effects, such as saving our items to local storage so they persist on a page refresh!',
+  'chapter-4/step-2':
+    'Chapter 4, Step 2:\n\nHooks added. But we have a problem in that we are not cleaning up after our hooks render or unmount. This can lead to unwanted side-effects.',
+  final: 'You made it! Bye bye React, hello your own version.',
 };

--- a/todo-app/public/walkthroughText.js
+++ b/todo-app/public/walkthroughText.js
@@ -1,0 +1,15 @@
+var walkthroughText = {
+  main: 'This app is currently using the real React. Checkout the branch chapter-1/step-1 to begin the journey to creating your own React.',
+  'chapter-1/step-1':
+    'Check out the render function in dom-handlers.js. This is where the rendering of elements to the DOM happens.',
+  'chapter-1/step-2': 'chapter-1/step-2',
+  'chapter-1/step-3': 'chapter-1/step-3',
+  'chapter-1/step-4': 'chapter-1/step-4',
+  'chapter-2/step-1': 'chapter-2/step-1',
+  'chapter-2/step-2': 'chapter-2/step-2',
+  'chapter-3/step-1': 'chapter-3/step-1',
+  'chapter-3/step-2': 'chapter-3/step-2',
+  'chapter-4/step-1': 'chapter-4/step-1',
+  'chapter-4/step-2': 'chapter-4/step-2',
+  final: '',
+};

--- a/todo-app/src/index.css
+++ b/todo-app/src/index.css
@@ -34,3 +34,72 @@ ul {
   margin-inline-end: 0px;
   padding-inline-start: 0;
 }
+
+/* The snackbar - position it at the bottom and in the middle of the screen */
+#snackbar {
+  visibility: hidden;
+  min-width: 250px;
+  width: 33%;
+  background-color: #efefef;
+  border: 1px solid #ff790f;
+  color: black;
+  border-radius: 2px;
+  padding: 16px;
+  position: fixed;
+  z-index: 1;
+  left: 32px;
+  bottom: 32px;
+  min-height: 101px;
+}
+
+#closeBtn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  border: none;
+  cursor: pointer;
+}
+
+#snackbarBtn {
+  position: fixed;
+  bottom: 32px;
+  left: 32px;
+  width: 140px;
+  padding: 8px;
+  border: 1px solid #ff790f;
+  color: black;
+  border-radius: 16px;
+  cursor: pointer;
+}
+
+#snackbarBtn:hover {
+  opacity: 0.8;
+}
+
+#snackbar.show {
+  visibility: visible;
+  -webkit-animation: fadein 0.5s;
+  animation: fadein 0.5s;
+}
+
+@-webkit-keyframes fadein {
+  from {
+    bottom: 0;
+    opacity: 0;
+  }
+  to {
+    bottom: 30px;
+    opacity: 1;
+  }
+}
+
+@keyframes fadein {
+  from {
+    bottom: 0;
+    opacity: 0;
+  }
+  to {
+    bottom: 30px;
+    opacity: 1;
+  }
+}

--- a/todo-app/src/index.css
+++ b/todo-app/src/index.css
@@ -43,21 +43,28 @@ ul {
   background-color: #efefef;
   border: 1px solid #ff790f;
   color: black;
-  border-radius: 2px;
+  border-radius: 5px;
   padding: 16px;
   position: fixed;
   z-index: 1;
   left: 32px;
   bottom: 32px;
   min-height: 101px;
+  display: flex;
+  white-space: pre-wrap;
+}
+
+#snackbarText {
+  margin: 0;
 }
 
 #closeBtn {
   position: absolute;
-  top: 2px;
+  top: 5px;
   right: 2px;
   border: none;
   cursor: pointer;
+  font-size: 14px;
 }
 
 #snackbarBtn {


### PR DESCRIPTION
I have added an in-app guide through a non-react snackbar component.
I've added a script that saves the git branch to a json, which is then used to fetch the correct "Step" text to populate the snackbar. 

I've also added husky to run the script on `post-checkout`, to ensure the text is updated when the user switches branches.

Need to still work out the text for each step and I'll update the styling so it's a bit fancier.

https://user-images.githubusercontent.com/16307049/203774135-2c969403-e67b-4ca0-9b1c-e43e656ed862.mov

